### PR TITLE
La línea 103 de json.go sobrepasa el número de caracteres permitidos 

### DIFF
--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -100,7 +100,7 @@ func main() {
 	// Esto tiene la ventaja de añadir seguridad adicional en el tipo
 	// para nuestros programas y eliminar la necesidad de afirmar el
 	// tipo al accesar los datos decifrados.
-	str := `{"pagina": 1, "frutas": ["manzana", "durazno"]}`
+	str := `{"pagina": 1, "frutas": ["manzana", "pera"]}`
 	res := &Respuesta2{}
 	json.Unmarshal([]byte(str), &res)
 	fmt.Println(res)

--- a/examples/json/json.sh
+++ b/examples/json/json.sh
@@ -4,15 +4,15 @@ true
 2.34
 "gopher"
 ["manzana","durazno","pera"]
-{"manzana":5,"lechuga":7}
+{"lechuga":7,"manzana":5}
 {"Pagina":1,"Frutas":["manzana","durazno","pera"]}
-{"paggina":1,"frutas":["manzana","durazno","pera"]}
+{"pagina":1,"frutas":["manzana","durazno","pera"]}
 map[num:6.13 strs:[a b]]
 6.13
 a
-&{1 [manzana durazno]}
+&{1 [manzana pera]}
 manzana
-{"manzana":5,"lechuga":7}
+{"lechuga":7,"manzana":5}
 
 
 # Aquí hemos cubierto lo básico de JSON para GO, pero 


### PR DESCRIPTION
La línea 103 provoca un error en el measure al hacer el build, el formato para mostrar el código de ejemplo sólo permite 58 caracteres