### PR TITLE
Traducción de Number Parsing

### DIFF
--- a/examples.txt
+++ b/examples.txt
@@ -49,7 +49,7 @@ Tiempo
 Epoch
 Análisis de formato de fecha
 Random Numbers
-Number Parsing
+Extracción de números de cadenas de texto
 URL Parsing
 SHA1 Hashes
 Base64 Encoding

--- a/examples/extraccion-de-numeros-de-cadenas-de-texto/extraccion-de-numeros-de-cadenas-de-texto.go
+++ b/examples/extraccion-de-numeros-de-cadenas-de-texto/extraccion-de-numeros-de-cadenas-de-texto.go
@@ -1,0 +1,49 @@
+// Extraer números contenidos en cadenas de texto es una tarea básica
+// pero común en muchos programas; he aquí cómo hacerlo en Go.
+
+package main
+
+// El paquete integrado `strconv` ([documentación aquí](http://golang.org/pkg/strconv/)) provee,
+// mediante 4 funciones, lo necesario para la extracción de números:
+// [`ParseFloat`](http://golang.org/pkg/strconv/#ParseFloat),
+// [`ParseInt`](http://golang.org/pkg/strconv/#ParseInt),
+// [`ParseUnit`](http://golang.org/pkg/strconv/#ParseUint) y
+// [`Atoi`](http://golang.org/pkg/strconv/#Atoi) (que viene de Ascii to Integer, Ascii a Entero).
+
+import "strconv"
+import "fmt"
+
+func main() {
+
+    // `ParseFloat`: el segundo argumento, el número `64`, especifica
+    // cuántos bits de precision se deben extraer.
+    f, _ := strconv.ParseFloat("1.234", 64)
+    fmt.Println(f)
+
+    // `ParseInt`: en este caso, el `0` especifica que se debe
+    // inferir la base dependiendo del valor de la cadena.
+    //`64` requiere que el resultado quepa en 64 bits.
+    i, _ := strconv.ParseInt("123", 0, 64)
+    fmt.Println(i)
+
+    // `ParseInt` reconoce números formateados en hexadecimal.
+    d, _ := strconv.ParseInt("0x1c8", 0, 64)
+    fmt.Println(d)
+
+    // `ParseUint` (para enteros sin signo)
+    u, _ := strconv.ParseUint("789", 0, 64)
+    fmt.Println(u)
+
+    // `Atoi` es una función para conversión básica
+    // de base 10 a `int` (entero);
+    // es equivalente a `ParseInt("135", 10, 0)`
+    k, _ := strconv.Atoi("135")
+    fmt.Println(k)
+
+    // Este tipo de funciones regresan un error
+    // si el argumento no es del tipo correcto,
+    // pero regresan `0` como primer valor.
+    z, e := strconv.Atoi("wat")
+    fmt.Println(e)
+    fmt.Println(z)
+}

--- a/examples/extraccion-de-numeros-de-cadenas-de-texto/extraccion-de-numeros-de-cadenas-de-texto.sh
+++ b/examples/extraccion-de-numeros-de-cadenas-de-texto/extraccion-de-numeros-de-cadenas-de-texto.sh
@@ -1,0 +1,8 @@
+$ go run extraccion-de-numeros-de-cadenas-de-texto.go
+1.234
+123
+456
+789
+135
+strconv.ParseInt: parsing "wat": invalid syntax
+0

--- a/public/extraccion-de-numeros-de-cadenas-de-texto
+++ b/public/extraccion-de-numeros-de-cadenas-de-texto
@@ -1,0 +1,217 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-eqiv="content-type" content="text/html;charset=utf-8">
+    <title>Go con Ejemplos: Extracción de números de cadenas de texto</title>
+    <link rel=stylesheet href="site.css">
+  </head>
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-51269806-1', 'goconejemplos.com');
+    ga('send', 'pageview');
+
+  </script>
+  <body>
+    <div class="example" id="extraccion-de-numeros-de-cadenas-de-texto">
+      <h2><a href="./">Go con Ejemplos</a>: Extracción de números de cadenas de texto</h2>
+      
+      <table>
+        
+        <tr>
+          <td class="docs">
+            <p>Extraer números contenidos en cadenas de texto es una tarea básica
+pero común en muchos programas; he aquí cómo hacerlo en Go.</p>
+
+          </td>
+          <td class="code empty leading">
+          
+            
+          </td>
+        </tr>
+        
+        <tr>
+          <td class="docs">
+            
+          </td>
+          <td class="code leading">
+          <a href="http://play.golang.org/p/4ztIkSuYE4"><img title="Run code" src="play.png" class="run" /></a>
+            <div class="highlight"><pre><span class="kn">package</span> <span class="nx">main</span>
+</pre></div>
+
+          </td>
+        </tr>
+        
+        <tr>
+          <td class="docs">
+            <p>El paquete integrado <code>strconv</code> (<a href="http://golang.org/pkg/strconv/">documentación aquí</a>) provee,
+mediante 4 funciones, lo necesario para la extracción de números:
+<a href="http://golang.org/pkg/strconv/#ParseFloat"><code>ParseFloat</code></a>,
+<a href="http://golang.org/pkg/strconv/#ParseInt"><code>ParseInt</code></a>,
+<a href="http://golang.org/pkg/strconv/#ParseUint"><code>ParseUnit</code></a> y
+<a href="http://golang.org/pkg/strconv/#Atoi"><code>Atoi</code></a> (que viene de Ascii to Integer, Ascii a Entero).</p>
+
+          </td>
+          <td class="code empty leading">
+          
+            
+          </td>
+        </tr>
+        
+        <tr>
+          <td class="docs">
+            
+          </td>
+          <td class="code leading">
+          
+            <div class="highlight"><pre><span class="kn">import</span> <span class="s">&quot;strconv&quot;</span>
+<span class="kn">import</span> <span class="s">&quot;fmt&quot;</span>
+</pre></div>
+
+          </td>
+        </tr>
+        
+        <tr>
+          <td class="docs">
+            
+          </td>
+          <td class="code leading">
+          
+            <div class="highlight"><pre><span class="kd">func</span> <span class="nx">main</span><span class="p">()</span> <span class="p">{</span>
+</pre></div>
+
+          </td>
+        </tr>
+        
+        <tr>
+          <td class="docs">
+            <p><code>ParseFloat</code>: el segundo argumento, el número <code>64</code>, especifica
+cuántos bits de precision se deben extraer.</p>
+
+          </td>
+          <td class="code leading">
+          
+            <div class="highlight"><pre>    <span class="nx">f</span><span class="p">,</span> <span class="nx">_</span> <span class="o">:=</span> <span class="nx">strconv</span><span class="p">.</span><span class="nx">ParseFloat</span><span class="p">(</span><span class="s">&quot;1.234&quot;</span><span class="p">,</span> <span class="mi">64</span><span class="p">)</span>
+    <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nx">f</span><span class="p">)</span>
+</pre></div>
+
+          </td>
+        </tr>
+        
+        <tr>
+          <td class="docs">
+            <p><code>ParseInt</code>: en este caso, el <code>0</code> especifica que se debe
+inferir la base dependiendo del valor de la cadena.</p>
+
+          </td>
+          <td class="code leading">
+          
+            <div class="highlight"><pre>    <span class="c1">//`64` requiere que el resultado quepa en 64 bits.</span>
+    <span class="nx">i</span><span class="p">,</span> <span class="nx">_</span> <span class="o">:=</span> <span class="nx">strconv</span><span class="p">.</span><span class="nx">ParseInt</span><span class="p">(</span><span class="s">&quot;123&quot;</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">64</span><span class="p">)</span>
+    <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nx">i</span><span class="p">)</span>
+</pre></div>
+
+          </td>
+        </tr>
+        
+        <tr>
+          <td class="docs">
+            <p><code>ParseInt</code> reconoce números formateados en hexadecimal.</p>
+
+          </td>
+          <td class="code leading">
+          
+            <div class="highlight"><pre>    <span class="nx">d</span><span class="p">,</span> <span class="nx">_</span> <span class="o">:=</span> <span class="nx">strconv</span><span class="p">.</span><span class="nx">ParseInt</span><span class="p">(</span><span class="s">&quot;0x1c8&quot;</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">64</span><span class="p">)</span>
+    <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nx">d</span><span class="p">)</span>
+</pre></div>
+
+          </td>
+        </tr>
+        
+        <tr>
+          <td class="docs">
+            <p><code>ParseUint</code> (para enteros sin signo)</p>
+
+          </td>
+          <td class="code leading">
+          
+            <div class="highlight"><pre>    <span class="nx">u</span><span class="p">,</span> <span class="nx">_</span> <span class="o">:=</span> <span class="nx">strconv</span><span class="p">.</span><span class="nx">ParseUint</span><span class="p">(</span><span class="s">&quot;789&quot;</span><span class="p">,</span> <span class="mi">0</span><span class="p">,</span> <span class="mi">64</span><span class="p">)</span>
+    <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nx">u</span><span class="p">)</span>
+</pre></div>
+
+          </td>
+        </tr>
+        
+        <tr>
+          <td class="docs">
+            <p><code>Atoi</code> es una función para conversión básica
+de base 10 a <code>int</code> (entero);
+es equivalente a <code>ParseInt(&quot;135&quot;, 10, 0)</code></p>
+
+          </td>
+          <td class="code leading">
+          
+            <div class="highlight"><pre>    <span class="nx">k</span><span class="p">,</span> <span class="nx">_</span> <span class="o">:=</span> <span class="nx">strconv</span><span class="p">.</span><span class="nx">Atoi</span><span class="p">(</span><span class="s">&quot;135&quot;</span><span class="p">)</span>
+    <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nx">k</span><span class="p">)</span>
+</pre></div>
+
+          </td>
+        </tr>
+        
+        <tr>
+          <td class="docs">
+            <p>Este tipo de funciones regresan un error
+si el argumento no es del tipo correcto,
+pero regresan <code>0</code> como primer valor.</p>
+
+          </td>
+          <td class="code">
+          
+            <div class="highlight"><pre>    <span class="nx">z</span><span class="p">,</span> <span class="nx">e</span> <span class="o">:=</span> <span class="nx">strconv</span><span class="p">.</span><span class="nx">Atoi</span><span class="p">(</span><span class="s">&quot;wat&quot;</span><span class="p">)</span>
+    <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nx">e</span><span class="p">)</span>
+    <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nx">z</span><span class="p">)</span>
+<span class="p">}</span>
+</pre></div>
+
+          </td>
+        </tr>
+        
+      </table>
+      
+      <table>
+        
+        <tr>
+          <td class="docs">
+            
+          </td>
+          <td class="code">
+          
+            <div class="highlight"><pre><span class="gp">$</span> go run extraccion-de-numeros-de-cadenas-de-texto.go
+<span class="go">1.234</span>
+<span class="go">123</span>
+<span class="go">456</span>
+<span class="go">789</span>
+<span class="go">135</span>
+<span class="go">strconv.ParseInt: parsing &quot;wat&quot;: invalid syntax</span>
+<span class="go">0</span>
+</pre></div>
+
+          </td>
+        </tr>
+        
+      </table>
+      
+      
+      <p class="next">
+        Siguiente ejemplo: <a href="url-parsing">URL Parsing</a>.
+      </p>
+      
+      <p class="footer">
+        by <a href="https://twitter.com/mmcgrana">@mmcgrana</a> | <a href="mailto:mmcgrana@gmail.com">feedback</a> | <a href="https://github.com/mmcgrana/gobyexample/blob/master/examples/extraccion-de-numeros-de-cadenas-de-texto">source</a> | <a href="https://github.com/mmcgrana/gobyexample#license">license</a>
+      </p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Traduje como `Extracción de números de cadenas de texto` porque no estoy de acuerdo en usar `Análisis de Números`, no me parece una traducción adecuada, pero si quieren que lo cambie, me avisan y lo hago.