### PR TITLE
Update format script for new gofmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ El proceso de publicación produce un directorio de archivos estáticos
 (`public`) perfecto para ser servido por cualquier servidor HTTP moderno.
 Además, se incluye un servidor web Go ligero en `server.go`.
 
+## Versiones de Go soportadas
+
+Las herramientas incluídas en `tools/` han sido probadas con 1.2.x, 1.3.x y 1.4.x, pero podrían funcionar
+con otras versiones.
+
 ### Compilación de ejemplos
 
 Para compilar el sitio:

--- a/examples/formateo-de-cadenas/formateo-de-cadenas.go
+++ b/examples/formateo-de-cadenas/formateo-de-cadenas.go
@@ -1,4 +1,4 @@
-// Go ofrece un excelente soporte para el formato de 
+// Go ofrece un excelente soporte para el formato de
 // cadenas siguiendo la tradición de `printf`. Aquí hay
 // algunos ejemplos de tareas comunes de formateo de
 // cadenas.
@@ -15,7 +15,7 @@ type point struct {
 func main() {
 
     // Go ofrece varios "verbos" de impresión, diseñados
-    // para dar formato a valores de Go simples. Por 
+    // para dar formato a valores de Go simples. Por
     // ejemplo, esto imprime una instancia de nuestra
     // estructura `point`.
     p := point{1, 2}
@@ -50,11 +50,11 @@ func main() {
     fmt.Printf("%x\n", 456)
 
     // Existen también varias opciones de formato para
-    // números de punto flotante. Para formato decimal 
+    // números de punto flotante. Para formato decimal
     // se usa `%f`.
     fmt.Printf("%f\n", 78.9)
 
-    // `%e` y `%E` dan formato a los números de punto 
+    // `%e` y `%E` dan formato a los números de punto
     // flotante usando (versiones ligeramente distintas
     //  de) la notación científica.
     fmt.Printf("%e\n", 123400000.0)
@@ -68,11 +68,11 @@ func main() {
     fmt.Printf("%q\n", "\"cadena\"")
 
     // Como con los enteros anteriormente, `%x` despliega
-    // la cadena en base-16 usando dos letras en la 
+    // la cadena en base-16 usando dos letras en la
     // salida por cada byte que haya en la entrada.
     fmt.Printf("%x\n", "hexadecimaleame esto")
 
-    // Para imprimir la representación de un apuntador 
+    // Para imprimir la representación de un apuntador
     // se usa `%p`.
     fmt.Printf("%p\n", &p)
 
@@ -86,33 +86,33 @@ func main() {
 
     // También puedes especificar el ancho de los números
     // de punto flotante y generalmente también se quiere
-    // restringir la precisión del punto decimal al mismo 
+    // restringir la precisión del punto decimal al mismo
     // tiempo. Esto se logra usando la sintáxis:
-    // ancho.precisión    
+    // ancho.precisión
     fmt.Printf("|%6.2f|%6.2f|\n", 1.2, 3.45)
 
-    // Para justificar a la izquierda se usa la bandera 
+    // Para justificar a la izquierda se usa la bandera
     // `-`.
     fmt.Printf("|%-6.2f|%-6.2f|\n", 1.2, 3.45)
 
     // También se puede querer controlar el ancho al dar
-    // formato a cadenas, especialmente si se requiere 
+    // formato a cadenas, especialmente si se requiere
     // que queden alineadas para salida tipo tabla. Para
     // justificación básica a la deerecha.
     fmt.Printf("|%6s|%6s|\n", "foo", "b")
 
-    // Para justificar a la izquierda se usa la bandera 
+    // Para justificar a la izquierda se usa la bandera
     // `-` al igual que en los números.
     fmt.Printf("|%-6s|%-6s|\n", "foo", "b")
 
     // Hasta ahora hemos usado `Printf`, que imprime la
     // cadena formateada a `os.Stdout`. `Sprintf` le da
-    // formato y regresa la cadena sin imprimirla en 
+    // formato y regresa la cadena sin imprimirla en
     // ningún lado.
     s := fmt.Sprintf("una %s", "cadena")
     fmt.Println(s)
 
-    // Se puede formateo-imprimir a otros `io.Writers` 
+    // Se puede formateo-imprimir a otros `io.Writers`
     // además de `os.Stdout` usando `Fprintf`.
     fmt.Fprintf(os.Stderr, "un %s\n", "error")
 }

--- a/examples/json/json.go
+++ b/examples/json/json.go
@@ -11,107 +11,107 @@ import "os"
 // Vamos a usar estas dos estructuras para demostrar cifrado y
 // descifrado de los tipos personalizados mostrados a continuación.
 type Respuesta1 struct {
-	Pagina int
-	Frutas []string
+    Pagina int
+    Frutas []string
 }
 type Respuesta2 struct {
-	Pagina int      `json:"pagina"`
-	Frutas []string `json:"frutas"`
+    Pagina int      `json:"pagina"`
+    Frutas []string `json:"frutas"`
 }
 
 func main() {
 
-	// Primero, vamos a hechar un vistazo al cifrado basico de tipos de datos
-	// a cadenas de JSON. Aqui hay algunos ejemplos para valores atómicos.
-	bolB, _ := json.Marshal(true)
-	fmt.Println(string(bolB))
+    // Primero, vamos a hechar un vistazo al cifrado basico de tipos de datos
+    // a cadenas de JSON. Aqui hay algunos ejemplos para valores atómicos.
+    bolB, _ := json.Marshal(true)
+    fmt.Println(string(bolB))
 
-	intB, _ := json.Marshal(1)
-	fmt.Println(string(intB))
+    intB, _ := json.Marshal(1)
+    fmt.Println(string(intB))
 
-	fltB, _ := json.Marshal(2.34)
-	fmt.Println(string(fltB))
+    fltB, _ := json.Marshal(2.34)
+    fmt.Println(string(fltB))
 
-	strB, _ := json.Marshal("gopher")
-	fmt.Println(string(strB))
+    strB, _ := json.Marshal("gopher")
+    fmt.Println(string(strB))
 
-	// Y aqui hay algunos para mapas y porciones(slices), donde
-	// se cifra a cadenas de JSON y objetos como se esperaría.
-	slcD := []string{"manzana", "durazno", "pera"}
-	slcB, _ := json.Marshal(slcD)
-	fmt.Println(string(slcB))
+    // Y aqui hay algunos para mapas y porciones(slices), donde
+    // se cifra a cadenas de JSON y objetos como se esperaría.
+    slcD := []string{"manzana", "durazno", "pera"}
+    slcB, _ := json.Marshal(slcD)
+    fmt.Println(string(slcB))
 
-	mapD := map[string]int{"manzana": 5, "lechuga": 7}
-	mapB, _ := json.Marshal(mapD)
-	fmt.Println(string(mapB))
+    mapD := map[string]int{"manzana": 5, "lechuga": 7}
+    mapB, _ := json.Marshal(mapD)
+    fmt.Println(string(mapB))
 
-	// El paquete JSON puede cifrar automaticamente tus
-	// tipos de datos personalizados. Solo incluirá campos
-	// exportados en el cifrado de salida y por defecto
-	// va a utilizar esos nombres como las llaves del JSON.
-	res1D := &Respuesta1{
-		Pagina: 1,
-		Frutas: []string{"manzana", "durazno", "pera"}}
-	res1B, _ := json.Marshal(res1D)
-	fmt.Println(string(res1B))
+    // El paquete JSON puede cifrar automaticamente tus
+    // tipos de datos personalizados. Solo incluirá campos
+    // exportados en el cifrado de salida y por defecto
+    // va a utilizar esos nombres como las llaves del JSON.
+    res1D := &Respuesta1{
+        Pagina: 1,
+        Frutas: []string{"manzana", "durazno", "pera"}}
+    res1B, _ := json.Marshal(res1D)
+    fmt.Println(string(res1B))
 
-	// Puedes usar etiquetas en las declaraciones de campos
-	// de estructuras para personalizar los nombres de las llaves
-	// del JSON cifrado. Mira la definición previa de `Respuesta2`
-	// para ver un ejemplo de esas etiquetas.
-	res2D := &Respuesta2{
-		Pagina: 1,
-		Frutas: []string{"manzana", "durazno", "pera"}}
-	res2B, _ := json.Marshal(res2D)
-	fmt.Println(string(res2B))
+    // Puedes usar etiquetas en las declaraciones de campos
+    // de estructuras para personalizar los nombres de las llaves
+    // del JSON cifrado. Mira la definición previa de `Respuesta2`
+    // para ver un ejemplo de esas etiquetas.
+    res2D := &Respuesta2{
+        Pagina: 1,
+        Frutas: []string{"manzana", "durazno", "pera"}}
+    res2B, _ := json.Marshal(res2D)
+    fmt.Println(string(res2B))
 
-	// Ahora echemos un vistazo al decifrado de datos de JSON
-	// a valores de Go. Aqui hay un ejemplo para una estructura
-	// genérica de datos.
-	byt := []byte(`{"num":6.13,"strs":["a","b"]}`)
+    // Ahora echemos un vistazo al decifrado de datos de JSON
+    // a valores de Go. Aqui hay un ejemplo para una estructura
+    // genérica de datos.
+    byt := []byte(`{"num":6.13,"strs":["a","b"]}`)
 
-	// Necesitamos proveer una variable donde el paquete
-	// JSON pueda colocar los datos decifrados. Este
-	// `map[string]interface{}` va a contener un mapa de
-	// cadenas para tipos de datos arbitrarios.
-	var dat map[string]interface{}
+    // Necesitamos proveer una variable donde el paquete
+    // JSON pueda colocar los datos decifrados. Este
+    // `map[string]interface{}` va a contener un mapa de
+    // cadenas para tipos de datos arbitrarios.
+    var dat map[string]interface{}
 
-	// Aqui está el decifrado real, y una verificación
-	// por errores asociados.
-	if err := json.Unmarshal(byt, &dat); err != nil {
-		panic(err)
-	}
-	fmt.Println(dat)
+    // Aqui está el decifrado real, y una verificación
+    // por errores asociados.
+    if err := json.Unmarshal(byt, &dat); err != nil {
+        panic(err)
+    }
+    fmt.Println(dat)
 
-	// A fin de usar los valores en el mapa decifrado,
-	// necesitaremos emitirlos a su tipo apropiado.
-	// Por ejemplo, aqui emitimos el valor en `num` al
-	// tipo esperado `float64`.
-	num := dat["num"].(float64)
-	fmt.Println(num)
+    // A fin de usar los valores en el mapa decifrado,
+    // necesitaremos emitirlos a su tipo apropiado.
+    // Por ejemplo, aqui emitimos el valor en `num` al
+    // tipo esperado `float64`.
+    num := dat["num"].(float64)
+    fmt.Println(num)
 
-	// Accesar a datos anidados necesita series de
-	// emisiones.
-	strs := dat["strs"].([]interface{})
-	str1 := strs[0].(string)
-	fmt.Println(str1)
+    // Accesar a datos anidados necesita series de
+    // emisiones.
+    strs := dat["strs"].([]interface{})
+    str1 := strs[0].(string)
+    fmt.Println(str1)
 
-	// También podemos decifrar JSON a tipos de datos personalizados.
-	// Esto tiene la ventaja de añadir seguridad adicional en el tipo
-	// para nuestros programas y eliminar la necesidad de afirmar el
-	// tipo al accesar los datos decifrados.
-	str := `{"pagina": 1, "frutas": ["manzana", "pera"]}`
-	res := &Respuesta2{}
-	json.Unmarshal([]byte(str), &res)
-	fmt.Println(res)
-	fmt.Println(res.Frutas[0])
+    // También podemos decifrar JSON a tipos de datos personalizados.
+    // Esto tiene la ventaja de añadir seguridad adicional en el tipo
+    // para nuestros programas y eliminar la necesidad de afirmar el
+    // tipo al accesar los datos decifrados.
+    str := `{"pagina": 1, "frutas": ["manzana", "pera"]}`
+    res := &Respuesta2{}
+    json.Unmarshal([]byte(str), &res)
+    fmt.Println(res)
+    fmt.Println(res.Frutas[0])
 
-	// En los ejemplos previos siempre usamos bytes y cadenas
-	// como intermediarios entre los datos y la represación del JSON
-	// de acuerdo al estandar. Además podemos correr cifrados JSON
-	// directamente a `os.Writer`s como `os.Stdout` o incluso
-	// en respuestas del cuerpo de HTTP.
-	enc := json.NewEncoder(os.Stdout)
-	d := map[string]int{"manzana": 5, "lechuga": 7}
-	enc.Encode(d)
+    // En los ejemplos previos siempre usamos bytes y cadenas
+    // como intermediarios entre los datos y la represación del JSON
+    // de acuerdo al estandar. Además podemos correr cifrados JSON
+    // directamente a `os.Writer`s como `os.Stdout` o incluso
+    // en respuestas del cuerpo de HTTP.
+    enc := json.NewEncoder(os.Stdout)
+    d := map[string]int{"manzana": 5, "lechuga": 7}
+    enc.Encode(d)
 }

--- a/examples/limitacion-de-transferencia/limitacion-de-transferencia.go
+++ b/examples/limitacion-de-transferencia/limitacion-de-transferencia.go
@@ -1,4 +1,4 @@
-// La limitación de tasa de transferencia es un mecanísmo 
+// La limitación de tasa de transferencia es un mecanísmo
 // importante para controlar la utilización de un
 // recurso y mantener la calidad del servicio. Go lo
 // soporta elegantemente usando gorutinas, canales y
@@ -12,7 +12,7 @@ import "fmt"
 func main() {
 
     // Primero veamos una limitación básica. Supongamos
-    // que queremos limirar el número de peticiones 
+    // que queremos limirar el número de peticiones
     // entrantes que podemos manejar. Serviremos estas
     // peticiones desde un canal con el mismo nombre.
     requests := make(chan int, 5)
@@ -22,12 +22,12 @@ func main() {
     close(requests)
 
     // Este canal `limiter` recibirá un valor cada 200
-    // milisegundos. Este es el regulador en nuestro 
-    // esquema limitador de transferencia. 
+    // milisegundos. Este es el regulador en nuestro
+    // esquema limitador de transferencia.
     limiter := time.Tick(time.Millisecond * 200)
 
-    // Al bloquear durante la recepción del canal 
-    // `limiter` antes de servir cada petición, nos 
+    // Al bloquear durante la recepción del canal
+    // `limiter` antes de servir cada petición, nos
     // autolimitamos a una petición cada 200 milisegundos
     for req := range requests {
         <-limiter
@@ -36,7 +36,7 @@ func main() {
 
     // Podriamos permitir pequeños picos de peticiones
     // en nuestro esquema de limitación y seguir
-    // conservando el limite general. Para lograrlo 
+    // conservando el limite general. Para lograrlo
     // podemos bufferear nuestro canal `limiter`. Este
     // canal `burstyLimiter` nos permitirá tener picos
     // de hasta 3 eventos.
@@ -56,7 +56,7 @@ func main() {
     }()
 
     // Ahora simularemos 5 peticiones más. La primera
-    // de estas 3 se beneficiará de la capacidad de 
+    // de estas 3 se beneficiará de la capacidad de
     // soportar picos del canal `burstyLimiter`.
     burstyRequests := make(chan int, 5)
     for i := 1; i <= 5; i++ {

--- a/public/base64-encoding
+++ b/public/base64-encoding
@@ -48,7 +48,7 @@ encoding/decoding</a>.</p>
         <tr>
           <td class="docs">
             <p>This syntax imports the <code>encoding/base64</code> package with
-the <code>b64</code> name instead of the default <code>base64</code>. It’ll
+the <code>b64</code> name instead of the default <code>base64</code>. It&rsquo;ll
 save us some space below.</p>
 
           </td>
@@ -75,7 +75,7 @@ save us some space below.</p>
         
         <tr>
           <td class="docs">
-            <p>Here’s the <code>string</code> we’ll encode/decode.</p>
+            <p>Here&rsquo;s the <code>string</code> we&rsquo;ll encode/decode.</p>
 
           </td>
           <td class="code leading">
@@ -89,7 +89,7 @@ save us some space below.</p>
         <tr>
           <td class="docs">
             <p>Go supports both standard and URL-compatible
-base64. Here’s how to encode using the standard
+base64. Here&rsquo;s how to encode using the standard
 encoder. The encoder requires a <code>[]byte</code> so we
 cast our <code>string</code> to that type.</p>
 
@@ -106,7 +106,7 @@ cast our <code>string</code> to that type.</p>
         <tr>
           <td class="docs">
             <p>Decoding may return an error, which you can check
-if you don’t already know the input to be
+if you don&rsquo;t already know the input to be
 well-formed.</p>
 
           </td>

--- a/public/canales
+++ b/public/canales
@@ -89,7 +89,7 @@ transportan.</p>
         <tr>
           <td class="docs">
             <p><em>Envía</em> un valor por un canal usando la sintaxis
-<code>canal &lt;-</code>. Aquí estamos enviando <code>&#34;ping&#34;</code> al canal
+<code>canal &lt;-</code>. Aquí estamos enviando <code>&quot;ping&quot;</code> al canal
 de <code>mensajes</code> que creamos arriba, de otra nueva
 goroutine.</p>
 
@@ -105,7 +105,7 @@ goroutine.</p>
         <tr>
           <td class="docs">
             <p>La sintaxis <code>&lt;-canal</code> <em>recibe</em> un valor del canal especificado.
-Aquí recibimos el mensaje <code>&#34;ping&#34;</code> que envíamos arriba
+Aquí recibimos el mensaje <code>&quot;ping&quot;</code> que envíamos arriba
 y lo mostramos en pantalla.</p>
 
           </td>
@@ -125,7 +125,7 @@ y lo mostramos en pantalla.</p>
         
         <tr>
           <td class="docs">
-            <p>Cuando corremos el programa el mensaje <code>&#34;ping&#34;</code> se
+            <p>Cuando corremos el programa el mensaje <code>&quot;ping&quot;</code> se
 pasa de una goroutine a otra a través de nuestro
 canal.</p>
 
@@ -144,7 +144,7 @@ canal.</p>
             <p>Por defecto la recepción y los envíos se bloquean hasta
 que ambos receptor y transmisor están listos. Esta
 propiedad nos permite esperar hasta el mensaje
-<code>&#34;ping&#34;</code> hasta el final del programa sin tener
+<code>&quot;ping&quot;</code> hasta el final del programa sin tener
 que usar ningún otro tipo de sincronización.</p>
 
           </td>

--- a/public/cerrando-canales
+++ b/public/cerrando-canales
@@ -122,7 +122,7 @@ canal <code>jobs</code> y luego lo cerramos.</p>
         <tr>
           <td class="docs">
             <p>Esperamos a que el trabajador termine usando la
-<a>sincronización</a> de
+<a href="sincronizacion-de-canales">sincronización</a> de
 canales que vimos anteriormente</p>
 
           </td>

--- a/public/collection-functions
+++ b/public/collection-functions
@@ -37,9 +37,9 @@ collection with a custom function.</p>
         
         <tr>
           <td class="docs">
-            <p>In some languages it’s idiomatic to use <a href="http://en.wikipedia.org/wiki/Generic_programming">generic</a>
+            <p>In some languages it&rsquo;s idiomatic to use <a href="http://en.wikipedia.org/wiki/Generic_programming">generic</a>
 data structures and algorithms. Go does not support
-generics; in Go it’s common to provide collection
+generics; in Go it&rsquo;s common to provide collection
 functions if and when they are specifically needed for
 your program and data types.</p>
 

--- a/public/command-line-arguments
+++ b/public/command-line-arguments
@@ -123,7 +123,7 @@ holds the arguments to the program.</p>
         
         <tr>
           <td class="docs">
-            <p>To experiment with command-line arguments it’s best to
+            <p>To experiment with command-line arguments it&rsquo;s best to
 build a binary with <code>go build</code> first.</p>
 
           </td>
@@ -141,7 +141,7 @@ build a binary with <code>go build</code> first.</p>
         
         <tr>
           <td class="docs">
-            <p>Next we’ll look at more advanced command-line processing
+            <p>Next we&rsquo;ll look at more advanced command-line processing
 with flags.</p>
 
           </td>

--- a/public/command-line-flags
+++ b/public/command-line-flags
@@ -50,7 +50,7 @@ command-line flag.</p>
         <tr>
           <td class="docs">
             <p>Go provides a <code>flag</code> package supporting basic
-command-line flag parsing. We’ll use this package to
+command-line flag parsing. We&rsquo;ll use this package to
 implement our example command-line program.</p>
 
           </td>
@@ -79,10 +79,10 @@ implement our example command-line program.</p>
           <td class="docs">
             <p>Basic flag declarations are available for string,
 integer, and boolean options. Here we declare a
-string flag <code>word</code> with a default value <code>&#34;foo&#34;</code>
+string flag <code>word</code> with a default value <code>&quot;foo&quot;</code>
 and a short description. This <code>flag.String</code> function
 returns a string pointer (not a string value);
-we’ll see how to use this pointer below.</p>
+we&rsquo;ll see how to use this pointer below.</p>
 
           </td>
           <td class="code leading">
@@ -110,7 +110,7 @@ similar approach to the <code>word</code> flag.</p>
         
         <tr>
           <td class="docs">
-            <p>It’s also possible to declare an option that uses an
+            <p>It&rsquo;s also possible to declare an option that uses an
 existing var declared elsewhere in the program.
 Note that we need to pass in a pointer to the flag
 declaration function.</p>
@@ -141,7 +141,7 @@ to execute the command-line parsing.</p>
         
         <tr>
           <td class="docs">
-            <p>Here we’ll just dump out the parsed options and
+            <p>Here we&rsquo;ll just dump out the parsed options and
 any trailing positional arguments. Note that we
 need to dereference the points with e.g. <code>*wordPtr</code>
 to get the actual option values.</p>
@@ -166,7 +166,7 @@ to get the actual option values.</p>
         
         <tr>
           <td class="docs">
-            <p>To experiment with the command-line flags program it’s
+            <p>To experiment with the command-line flags program it&rsquo;s
 best to first compile it and then run the resulting
 binary directly.</p>
 
@@ -275,7 +275,7 @@ generated help text for the command-line program.</p>
         
         <tr>
           <td class="docs">
-            <p>If you provide a flag that wasn’t specified to the
+            <p>If you provide a flag that wasn&rsquo;t specified to the
 <code>flag</code> package, the program will print an error message
 an show the help text again.</p>
 
@@ -293,7 +293,7 @@ an show the help text again.</p>
         
         <tr>
           <td class="docs">
-            <p>Next we’ll look at environment variables, another common
+            <p>Next we&rsquo;ll look at environment variables, another common
 way to parameterize programs.</p>
 
           </td>

--- a/public/contadores-atomicos
+++ b/public/contadores-atomicos
@@ -25,7 +25,7 @@
           <td class="docs">
             <p>El mecanismo principal para manejar estados en Go es la comunicación
 mediante canales (channels).  Podemos ver esto, por ejemplo, con los
-<a><em>worker-pools</em></a>. Además de canales existen otras formas para
+<a href="worker-pools"><em>worker-pools</em></a>. Además de canales existen otras formas para
 manejar estados.  En éste código conoceremos el uso del paquete
 <code>sync/atomic</code> para <em>contadores atómicos</em>, los cuales pueden ser accedidos
 por múltiples <em>goroutines</em>.</p>

--- a/public/exit
+++ b/public/exit
@@ -102,7 +102,7 @@ this <code>fmt.Println</code> will never be called.</p>
           <td class="docs">
             <p>Note that unlike e.g. C, Go does not use an integer
 return value from <code>main</code> to indicate exit status. If
-you’d like to exit with a non-zero status you should
+you&rsquo;d like to exit with a non-zero status you should
 use <code>os.Exit</code>.</p>
 
           </td>

--- a/public/expresiones-regulares
+++ b/public/expresiones-regulares
@@ -146,7 +146,7 @@ texto.</p>
         
         <tr>
           <td class="docs">
-            <p>Las variantes ‘Submatch’ incluyen información sobre las
+            <p>Las variantes &lsquo;Submatch&rsquo; incluyen información sobre las
 coincidencias completas y parciales. Este ejemplo
 devuelve información de las coincidencias de los patrones
 <code>p([a-z]+)ch</code> and <code>([a-z]+)</code>.</p>
@@ -176,7 +176,7 @@ sobre los índices de coincidencias y subcoincidencias.</p>
         
         <tr>
           <td class="docs">
-            <p>Las variantes ‘All’ de las funciones aplican para todas
+            <p>Las variantes &lsquo;All&rsquo; de las funciones aplican para todas
 las coincidencias del texto de entrada, no solo para el
 principio. Por ejemplo para encontrar todas las
 coincidencias de una expresión regular.</p>
@@ -192,7 +192,7 @@ coincidencias de una expresión regular.</p>
         
         <tr>
           <td class="docs">
-            <p>Estas variantes ‘All’ están disponibles para las
+            <p>Estas variantes &lsquo;All&rsquo; están disponibles para las
 demás funciones que vimos anteriormente.</p>
 
           </td>
@@ -222,8 +222,8 @@ parámetro limitará el numbero de coindencias.</p>
         <tr>
           <td class="docs">
             <p>Los ejemplos anteriores tienen argumentos de cadena
-y usan nombres como ‘MatchString’. También podemos
-usar argumentos ‘[]byte’ y eliminar ‘String’ del
+y usan nombres como &lsquo;MatchString&rsquo;. También podemos
+usar argumentos &lsquo;[]byte&rsquo; y eliminar &lsquo;String&rsquo; del
 nombre de la función.
 Our examples above had string arguments and used
 names like <code>MatchString</code>. We can also provide
@@ -242,8 +242,8 @@ function name.</p>
         <tr>
           <td class="docs">
             <p>Cuando creamos constantes con expresiones regulares
-puedes utilizar la variante ‘MustCompile’ en lugar
-de ‘Compile’. La llamada ‘Compile’ no funcionará
+puedes utilizar la variante &lsquo;MustCompile&rsquo; en lugar
+de &lsquo;Compile&rsquo;. La llamada &lsquo;Compile&rsquo; no funcionará
 para crear contantes porque devuelve dos valores.</p>
 
           </td>
@@ -272,7 +272,7 @@ reemplazar subcadenas de texto con otros valores.</p>
         
         <tr>
           <td class="docs">
-            <p>La variante ‘Func’ permite transformar el texto
+            <p>La variante &lsquo;Func&rsquo; permite transformar el texto
 que coincide mediante una función.</p>
 
           </td>

--- a/public/formateo-de-cadenas
+++ b/public/formateo-de-cadenas
@@ -40,7 +40,7 @@ cadenas.</p>
             
           </td>
           <td class="code leading">
-          <a href="http://play.golang.org/p/PrxjUESI6t"><img title="Run code" src="play.png" class="run" /></a>
+          <a href="http://play.golang.org/p/TLwZJSrapB"><img title="Run code" src="play.png" class="run" /></a>
             <div class="highlight"><pre><span class="kn">package</span> <span class="nx">main</span>
 </pre></div>
 
@@ -88,7 +88,7 @@ cadenas.</p>
         
         <tr>
           <td class="docs">
-            <p>Go ofrece varios “verbos” de impresión, diseñados
+            <p>Go ofrece varios &ldquo;verbos&rdquo; de impresión, diseñados
 para dar formato a valores de Go simples. Por
 ejemplo, esto imprime una instancia de nuestra
 estructura <code>point</code>.</p>
@@ -452,7 +452,7 @@ además de <code>os.Stdout</code> usando <code>Fprintf</code>.</p>
       
       
       <p class="next">
-        Siguiente ejemplo: <a href="regular-expressions">Regular Expressions</a>.
+        Siguiente ejemplo: <a href="expresiones-regulares">Expresiones regulares</a>.
       </p>
       
       <p class="footer">

--- a/public/hola-mundo
+++ b/public/hola-mundo
@@ -24,7 +24,7 @@
         <tr>
           <td class="docs">
             <p>Nuestro primer programa mostrará en la pantalla el mensaje clásico
-“hola mundo”. Aquí el código completo.</p>
+&ldquo;hola mundo&rdquo;. Aquí el código completo.</p>
 
           </td>
           <td class="code leading">

--- a/public/if-else
+++ b/public/if-else
@@ -38,7 +38,7 @@ se hace de manera directa.</p>
             
           </td>
           <td class="code leading">
-          <a href="http://play.golang.org/p/bVFGOHjgw9"><img title="Run code" src="play.png" class="run" /></a>
+          <a href="http://play.golang.org/p/hi-h_RAxmC"><img title="Run code" src="play.png" class="run" /></a>
             <div class="highlight"><pre><span class="kn">package</span> <span class="nx">main</span>
 </pre></div>
 
@@ -77,9 +77,9 @@ se hace de manera directa.</p>
           <td class="code leading">
           
             <div class="highlight"><pre>    <span class="k">if</span> <span class="mi">7</span><span class="o">%</span><span class="mi">2</span> <span class="o">==</span> <span class="mi">0</span> <span class="p">{</span>
-        <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="s">&quot;7 is even&quot;</span><span class="p">)</span>
+        <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="s">&quot;7 es par&quot;</span><span class="p">)</span>
     <span class="p">}</span> <span class="k">else</span> <span class="p">{</span>
-        <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="s">&quot;7 is odd&quot;</span><span class="p">)</span>
+        <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="s">&quot;7 es impar&quot;</span><span class="p">)</span>
     <span class="p">}</span>
 </pre></div>
 
@@ -94,7 +94,7 @@ se hace de manera directa.</p>
           <td class="code leading">
           
             <div class="highlight"><pre>    <span class="k">if</span> <span class="mi">8</span><span class="o">%</span><span class="mi">4</span> <span class="o">==</span> <span class="mi">0</span> <span class="p">{</span>
-        <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="s">&quot;8 is divisible by 4&quot;</span><span class="p">)</span>
+        <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="s">&quot;8 es divisible entre 4&quot;</span><span class="p">)</span>
     <span class="p">}</span>
 </pre></div>
 
@@ -112,11 +112,11 @@ en todas las derivaciones.</p>
           <td class="code leading">
           
             <div class="highlight"><pre>    <span class="k">if</span> <span class="nx">num</span> <span class="o">:=</span> <span class="mi">9</span><span class="p">;</span> <span class="nx">num</span> <span class="p">&lt;</span> <span class="mi">0</span> <span class="p">{</span>
-        <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nx">num</span><span class="p">,</span> <span class="s">&quot;is negative&quot;</span><span class="p">)</span>
+        <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nx">num</span><span class="p">,</span> <span class="s">&quot;es negativo&quot;</span><span class="p">)</span>
     <span class="p">}</span> <span class="k">else</span> <span class="k">if</span> <span class="nx">num</span> <span class="p">&lt;</span> <span class="mi">10</span> <span class="p">{</span>
-        <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nx">num</span><span class="p">,</span> <span class="s">&quot;has 1 digit&quot;</span><span class="p">)</span>
+        <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nx">num</span><span class="p">,</span> <span class="s">&quot;tiene 1 digito&quot;</span><span class="p">)</span>
     <span class="p">}</span> <span class="k">else</span> <span class="p">{</span>
-        <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nx">num</span><span class="p">,</span> <span class="s">&quot;has multiple digits&quot;</span><span class="p">)</span>
+        <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nx">num</span><span class="p">,</span> <span class="s">&quot;tiene multiples digitos&quot;</span><span class="p">)</span>
     <span class="p">}</span>
 <span class="p">}</span>
 </pre></div>
@@ -147,9 +147,9 @@ condiciones en Go, pero las llaves {} si son obligatorias.</p>
           <td class="code leading">
           
             <div class="highlight"><pre><span class="gp">$</span> go run <span class="k">if</span>-else.go
-<span class="go">7 is odd</span>
-<span class="go">8 is divisible by 4</span>
-<span class="go">9 has 1 digit</span>
+<span class="go">7 es impar</span>
+<span class="go">8 es divisible entre 4</span>
+<span class="go">9 tiene 1 digito</span>
 </pre></div>
 
           </td>

--- a/public/json
+++ b/public/json
@@ -23,9 +23,9 @@
         
         <tr>
           <td class="docs">
-            <p>Go offers built-in support for JSON encoding and
-decoding, including to and from built-in and custom
-data types.</p>
+            <p>Go ofrece soporte incluido para codificar y descifrar JSON,
+incluyendo desde tipos de datos incorporados hasta
+tipos de datos personalizados.</p>
 
           </td>
           <td class="code empty leading">
@@ -39,7 +39,7 @@ data types.</p>
             
           </td>
           <td class="code leading">
-          <a href="http://play.golang.org/p/scgxBwACYx"><img title="Run code" src="play.png" class="run" /></a>
+          <a href="http://play.golang.org/p/xpzcNZeKNX"><img title="Run code" src="play.png" class="run" /></a>
             <div class="highlight"><pre><span class="kn">package</span> <span class="nx">main</span>
 </pre></div>
 
@@ -62,19 +62,19 @@ data types.</p>
         
         <tr>
           <td class="docs">
-            <p>We’ll use these two structs to demonstrate encoding and
-decoding of custom types below.</p>
+            <p>Vamos a usar estas dos estructuras para demostrar cifrado y
+descifrado de los tipos personalizados mostrados a continuación.</p>
 
           </td>
           <td class="code leading">
           
-            <div class="highlight"><pre><span class="kd">type</span> <span class="nx">Response1</span> <span class="kd">struct</span> <span class="p">{</span>
-    <span class="nx">Page</span>   <span class="kt">int</span>
-    <span class="nx">Fruits</span> <span class="p">[]</span><span class="kt">string</span>
+            <div class="highlight"><pre><span class="kd">type</span> <span class="nx">Respuesta1</span> <span class="kd">struct</span> <span class="p">{</span>
+    <span class="nx">Pagina</span> <span class="kt">int</span>
+    <span class="nx">Frutas</span> <span class="p">[]</span><span class="kt">string</span>
 <span class="p">}</span>
-<span class="kd">type</span> <span class="nx">Response2</span> <span class="kd">struct</span> <span class="p">{</span>
-    <span class="nx">Page</span>   <span class="kt">int</span>      <span class="s">`json:&quot;page&quot;`</span>
-    <span class="nx">Fruits</span> <span class="p">[]</span><span class="kt">string</span> <span class="s">`json:&quot;fruits&quot;`</span>
+<span class="kd">type</span> <span class="nx">Respuesta2</span> <span class="kd">struct</span> <span class="p">{</span>
+    <span class="nx">Pagina</span> <span class="kt">int</span>      <span class="s">`json:&quot;pagina&quot;`</span>
+    <span class="nx">Frutas</span> <span class="p">[]</span><span class="kt">string</span> <span class="s">`json:&quot;frutas&quot;`</span>
 <span class="p">}</span>
 </pre></div>
 
@@ -95,9 +95,8 @@ decoding of custom types below.</p>
         
         <tr>
           <td class="docs">
-            <p>First we’ll look at encoding basic data types to
-JSON strings. Here are some examples for atomic
-values.</p>
+            <p>Primero, vamos a hechar un vistazo al cifrado basico de tipos de datos
+a cadenas de JSON. Aqui hay algunos ejemplos para valores atómicos.</p>
 
           </td>
           <td class="code leading">
@@ -150,13 +149,13 @@ values.</p>
         
         <tr>
           <td class="docs">
-            <p>And here are some for slices and maps, which encode
-to JSON arrays and objects as you’d expect.</p>
+            <p>Y aqui hay algunos para mapas y porciones(slices), donde
+se cifra a cadenas de JSON y objetos como se esperaría.</p>
 
           </td>
           <td class="code leading">
           
-            <div class="highlight"><pre>    <span class="nx">slcD</span> <span class="o">:=</span> <span class="p">[]</span><span class="kt">string</span><span class="p">{</span><span class="s">&quot;apple&quot;</span><span class="p">,</span> <span class="s">&quot;peach&quot;</span><span class="p">,</span> <span class="s">&quot;pear&quot;</span><span class="p">}</span>
+            <div class="highlight"><pre>    <span class="nx">slcD</span> <span class="o">:=</span> <span class="p">[]</span><span class="kt">string</span><span class="p">{</span><span class="s">&quot;manzana&quot;</span><span class="p">,</span> <span class="s">&quot;durazno&quot;</span><span class="p">,</span> <span class="s">&quot;pera&quot;</span><span class="p">}</span>
     <span class="nx">slcB</span><span class="p">,</span> <span class="nx">_</span> <span class="o">:=</span> <span class="nx">json</span><span class="p">.</span><span class="nx">Marshal</span><span class="p">(</span><span class="nx">slcD</span><span class="p">)</span>
     <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nb">string</span><span class="p">(</span><span class="nx">slcB</span><span class="p">))</span>
 </pre></div>
@@ -170,7 +169,7 @@ to JSON arrays and objects as you’d expect.</p>
           </td>
           <td class="code leading">
           
-            <div class="highlight"><pre>    <span class="nx">mapD</span> <span class="o">:=</span> <span class="kd">map</span><span class="p">[</span><span class="kt">string</span><span class="p">]</span><span class="kt">int</span><span class="p">{</span><span class="s">&quot;apple&quot;</span><span class="p">:</span> <span class="mi">5</span><span class="p">,</span> <span class="s">&quot;lettuce&quot;</span><span class="p">:</span> <span class="mi">7</span><span class="p">}</span>
+            <div class="highlight"><pre>    <span class="nx">mapD</span> <span class="o">:=</span> <span class="kd">map</span><span class="p">[</span><span class="kt">string</span><span class="p">]</span><span class="kt">int</span><span class="p">{</span><span class="s">&quot;manzana&quot;</span><span class="p">:</span> <span class="mi">5</span><span class="p">,</span> <span class="s">&quot;lechuga&quot;</span><span class="p">:</span> <span class="mi">7</span><span class="p">}</span>
     <span class="nx">mapB</span><span class="p">,</span> <span class="nx">_</span> <span class="o">:=</span> <span class="nx">json</span><span class="p">.</span><span class="nx">Marshal</span><span class="p">(</span><span class="nx">mapD</span><span class="p">)</span>
     <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nb">string</span><span class="p">(</span><span class="nx">mapB</span><span class="p">))</span>
 </pre></div>
@@ -180,17 +179,17 @@ to JSON arrays and objects as you’d expect.</p>
         
         <tr>
           <td class="docs">
-            <p>The JSON package can automatically encode your
-custom data types. It will only include exported
-fields in the encoded output and will by default
-use those names as the JSON keys.</p>
+            <p>El paquete JSON puede cifrar automaticamente tus
+tipos de datos personalizados. Solo incluirá campos
+exportados en el cifrado de salida y por defecto
+va a utilizar esos nombres como las llaves del JSON.</p>
 
           </td>
           <td class="code leading">
           
-            <div class="highlight"><pre>    <span class="nx">res1D</span> <span class="o">:=</span> <span class="o">&amp;</span><span class="nx">Response1</span><span class="p">{</span>
-        <span class="nx">Page</span><span class="p">:</span>   <span class="mi">1</span><span class="p">,</span>
-        <span class="nx">Fruits</span><span class="p">:</span> <span class="p">[]</span><span class="kt">string</span><span class="p">{</span><span class="s">&quot;apple&quot;</span><span class="p">,</span> <span class="s">&quot;peach&quot;</span><span class="p">,</span> <span class="s">&quot;pear&quot;</span><span class="p">}}</span>
+            <div class="highlight"><pre>    <span class="nx">res1D</span> <span class="o">:=</span> <span class="o">&amp;</span><span class="nx">Respuesta1</span><span class="p">{</span>
+        <span class="nx">Pagina</span><span class="p">:</span> <span class="mi">1</span><span class="p">,</span>
+        <span class="nx">Frutas</span><span class="p">:</span> <span class="p">[]</span><span class="kt">string</span><span class="p">{</span><span class="s">&quot;manzana&quot;</span><span class="p">,</span> <span class="s">&quot;durazno&quot;</span><span class="p">,</span> <span class="s">&quot;pera&quot;</span><span class="p">}}</span>
     <span class="nx">res1B</span><span class="p">,</span> <span class="nx">_</span> <span class="o">:=</span> <span class="nx">json</span><span class="p">.</span><span class="nx">Marshal</span><span class="p">(</span><span class="nx">res1D</span><span class="p">)</span>
     <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nb">string</span><span class="p">(</span><span class="nx">res1B</span><span class="p">))</span>
 </pre></div>
@@ -200,17 +199,17 @@ use those names as the JSON keys.</p>
         
         <tr>
           <td class="docs">
-            <p>You can use tags on struct field declarations
-to customize the encoded JSON key names. Check the
-definition of <code>Response2</code> above to see an example
-of such tags.</p>
+            <p>Puedes usar etiquetas en las declaraciones de campos
+de estructuras para personalizar los nombres de las llaves
+del JSON cifrado. Mira la definición previa de <code>Respuesta2</code>
+para ver un ejemplo de esas etiquetas.</p>
 
           </td>
           <td class="code leading">
           
-            <div class="highlight"><pre>    <span class="nx">res2D</span> <span class="o">:=</span> <span class="o">&amp;</span><span class="nx">Response2</span><span class="p">{</span>
-        <span class="nx">Page</span><span class="p">:</span>   <span class="mi">1</span><span class="p">,</span>
-        <span class="nx">Fruits</span><span class="p">:</span> <span class="p">[]</span><span class="kt">string</span><span class="p">{</span><span class="s">&quot;apple&quot;</span><span class="p">,</span> <span class="s">&quot;peach&quot;</span><span class="p">,</span> <span class="s">&quot;pear&quot;</span><span class="p">}}</span>
+            <div class="highlight"><pre>    <span class="nx">res2D</span> <span class="o">:=</span> <span class="o">&amp;</span><span class="nx">Respuesta2</span><span class="p">{</span>
+        <span class="nx">Pagina</span><span class="p">:</span> <span class="mi">1</span><span class="p">,</span>
+        <span class="nx">Frutas</span><span class="p">:</span> <span class="p">[]</span><span class="kt">string</span><span class="p">{</span><span class="s">&quot;manzana&quot;</span><span class="p">,</span> <span class="s">&quot;durazno&quot;</span><span class="p">,</span> <span class="s">&quot;pera&quot;</span><span class="p">}}</span>
     <span class="nx">res2B</span><span class="p">,</span> <span class="nx">_</span> <span class="o">:=</span> <span class="nx">json</span><span class="p">.</span><span class="nx">Marshal</span><span class="p">(</span><span class="nx">res2D</span><span class="p">)</span>
     <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nb">string</span><span class="p">(</span><span class="nx">res2B</span><span class="p">))</span>
 </pre></div>
@@ -220,9 +219,9 @@ of such tags.</p>
         
         <tr>
           <td class="docs">
-            <p>Now let’s look at decoding JSON data into Go
-values. Here’s an example for a generic data
-structure.</p>
+            <p>Ahora echemos un vistazo al decifrado de datos de JSON
+a valores de Go. Aqui hay un ejemplo para una estructura
+genérica de datos.</p>
 
           </td>
           <td class="code leading">
@@ -235,10 +234,10 @@ structure.</p>
         
         <tr>
           <td class="docs">
-            <p>We need to provide a variable where the JSON
-package can put the decoded data. This
-<code>map[string]interface{}</code> will hold a map of strings
-to arbitrary data types.</p>
+            <p>Necesitamos proveer una variable donde el paquete
+JSON pueda colocar los datos decifrados. Este
+<code>map[string]interface{}</code> va a contener un mapa de
+cadenas para tipos de datos arbitrarios.</p>
 
           </td>
           <td class="code leading">
@@ -251,8 +250,8 @@ to arbitrary data types.</p>
         
         <tr>
           <td class="docs">
-            <p>Here’s the actual decoding, and a check for
-associated errors.</p>
+            <p>Aqui está el decifrado real, y una verificación
+por errores asociados.</p>
 
           </td>
           <td class="code leading">
@@ -268,10 +267,10 @@ associated errors.</p>
         
         <tr>
           <td class="docs">
-            <p>In order to use the values in the decoded map,
-we’ll need to cast them to their appropriate type.
-For example here we cast the value in <code>num</code> to
-the expected <code>float64</code> type.</p>
+            <p>A fin de usar los valores en el mapa decifrado,
+necesitaremos emitirlos a su tipo apropiado.
+Por ejemplo, aqui emitimos el valor en <code>num</code> al
+tipo esperado <code>float64</code>.</p>
 
           </td>
           <td class="code leading">
@@ -285,8 +284,8 @@ the expected <code>float64</code> type.</p>
         
         <tr>
           <td class="docs">
-            <p>Accessing nested data requires a series of
-casts.</p>
+            <p>Accesar a datos anidados necesita series de
+emisiones.</p>
 
           </td>
           <td class="code leading">
@@ -301,20 +300,19 @@ casts.</p>
         
         <tr>
           <td class="docs">
-            <p>We can also decode JSON into custom data types.
-This has the advantages of adding additional
-type-safety to our programs and eliminating the
-need for type assertions when accessing the decoded
-data.</p>
+            <p>También podemos decifrar JSON a tipos de datos personalizados.
+Esto tiene la ventaja de añadir seguridad adicional en el tipo
+para nuestros programas y eliminar la necesidad de afirmar el
+tipo al accesar los datos decifrados.</p>
 
           </td>
           <td class="code leading">
           
-            <div class="highlight"><pre>    <span class="nx">str</span> <span class="o">:=</span> <span class="s">`{&quot;page&quot;: 1, &quot;fruits&quot;: [&quot;apple&quot;, &quot;peach&quot;]}`</span>
-    <span class="nx">res</span> <span class="o">:=</span> <span class="o">&amp;</span><span class="nx">Response2</span><span class="p">{}</span>
+            <div class="highlight"><pre>    <span class="nx">str</span> <span class="o">:=</span> <span class="s">`{&quot;pagina&quot;: 1, &quot;frutas&quot;: [&quot;manzana&quot;, &quot;pera&quot;]}`</span>
+    <span class="nx">res</span> <span class="o">:=</span> <span class="o">&amp;</span><span class="nx">Respuesta2</span><span class="p">{}</span>
     <span class="nx">json</span><span class="p">.</span><span class="nx">Unmarshal</span><span class="p">([]</span><span class="nb">byte</span><span class="p">(</span><span class="nx">str</span><span class="p">),</span> <span class="o">&amp;</span><span class="nx">res</span><span class="p">)</span>
     <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nx">res</span><span class="p">)</span>
-    <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nx">res</span><span class="p">.</span><span class="nx">Fruits</span><span class="p">[</span><span class="mi">0</span><span class="p">])</span>
+    <span class="nx">fmt</span><span class="p">.</span><span class="nx">Println</span><span class="p">(</span><span class="nx">res</span><span class="p">.</span><span class="nx">Frutas</span><span class="p">[</span><span class="mi">0</span><span class="p">])</span>
 </pre></div>
 
           </td>
@@ -322,17 +320,17 @@ data.</p>
         
         <tr>
           <td class="docs">
-            <p>In the examples above we always used bytes and
-strings as intermediates between the data and
-JSON representation on standard out. We can also
-stream JSON encodings directly to <code>os.Writer</code>s like
-<code>os.Stdout</code> or even HTTP response bodies.</p>
+            <p>En los ejemplos previos siempre usamos bytes y cadenas
+como intermediarios entre los datos y la represación del JSON
+de acuerdo al estandar. Además podemos correr cifrados JSON
+directamente a <code>os.Writer</code>s como <code>os.Stdout</code> o incluso
+en respuestas del cuerpo de HTTP.</p>
 
           </td>
           <td class="code">
           
             <div class="highlight"><pre>    <span class="nx">enc</span> <span class="o">:=</span> <span class="nx">json</span><span class="p">.</span><span class="nx">NewEncoder</span><span class="p">(</span><span class="nx">os</span><span class="p">.</span><span class="nx">Stdout</span><span class="p">)</span>
-    <span class="nx">d</span> <span class="o">:=</span> <span class="kd">map</span><span class="p">[</span><span class="kt">string</span><span class="p">]</span><span class="kt">int</span><span class="p">{</span><span class="s">&quot;apple&quot;</span><span class="p">:</span> <span class="mi">5</span><span class="p">,</span> <span class="s">&quot;lettuce&quot;</span><span class="p">:</span> <span class="mi">7</span><span class="p">}</span>
+    <span class="nx">d</span> <span class="o">:=</span> <span class="kd">map</span><span class="p">[</span><span class="kt">string</span><span class="p">]</span><span class="kt">int</span><span class="p">{</span><span class="s">&quot;manzana&quot;</span><span class="p">:</span> <span class="mi">5</span><span class="p">,</span> <span class="s">&quot;lechuga&quot;</span><span class="p">:</span> <span class="mi">7</span><span class="p">}</span>
     <span class="nx">enc</span><span class="p">.</span><span class="nx">Encode</span><span class="p">(</span><span class="nx">d</span><span class="p">)</span>
 <span class="p">}</span>
 </pre></div>
@@ -355,16 +353,16 @@ stream JSON encodings directly to <code>os.Writer</code>s like
 <span class="go">1</span>
 <span class="go">2.34</span>
 <span class="go">&quot;gopher&quot;</span>
-<span class="go">[&quot;apple&quot;,&quot;peach&quot;,&quot;pear&quot;]</span>
-<span class="go">{&quot;apple&quot;:5,&quot;lettuce&quot;:7}</span>
-<span class="go">{&quot;Page&quot;:1,&quot;Fruits&quot;:[&quot;apple&quot;,&quot;peach&quot;,&quot;pear&quot;]}</span>
-<span class="go">{&quot;page&quot;:1,&quot;fruits&quot;:[&quot;apple&quot;,&quot;peach&quot;,&quot;pear&quot;]}</span>
+<span class="go">[&quot;manzana&quot;,&quot;durazno&quot;,&quot;pera&quot;]</span>
+<span class="go">{&quot;lechuga&quot;:7,&quot;manzana&quot;:5}</span>
+<span class="go">{&quot;Pagina&quot;:1,&quot;Frutas&quot;:[&quot;manzana&quot;,&quot;durazno&quot;,&quot;pera&quot;]}</span>
+<span class="go">{&quot;pagina&quot;:1,&quot;frutas&quot;:[&quot;manzana&quot;,&quot;durazno&quot;,&quot;pera&quot;]}</span>
 <span class="go">map[num:6.13 strs:[a b]]</span>
 <span class="go">6.13</span>
 <span class="go">a</span>
-<span class="go">&amp;{1 [apple peach]}</span>
-<span class="go">apple</span>
-<span class="go">{&quot;apple&quot;:5,&quot;lettuce&quot;:7}</span>
+<span class="go">&amp;{1 [manzana pera]}</span>
+<span class="go">manzana</span>
+<span class="go">{&quot;lechuga&quot;:7,&quot;manzana&quot;:5}</span>
 </pre></div>
 
           </td>
@@ -372,10 +370,10 @@ stream JSON encodings directly to <code>os.Writer</code>s like
         
         <tr>
           <td class="docs">
-            <p>We’ve covered the basic of JSON in Go here, but check
-out the <a href="http://blog.golang.org/2011/01/json-and-go.html">JSON and Go</a>
-blog post and <a href="http://golang.org/pkg/encoding/json/">JSON package docs</a>
-for more.</p>
+            <p>Aquí hemos cubierto lo básico de JSON para GO, pero
+no olvides el post en el blog <a href="http://blog.golang.org/2011/01/json-and-go.html">JSON y Go</a>
+y <a href="http://golang.org/pkg/encoding/json/">JSON package docs</a>
+para más información.</p>
 
           </td>
           <td class="code empty">

--- a/public/limitacion-de-transferencia
+++ b/public/limitacion-de-transferencia
@@ -41,7 +41,7 @@ soporta elegantemente usando gorutinas, canales y
             
           </td>
           <td class="code leading">
-          <a href="http://play.golang.org/p/eeVQ_fQ8Jq"><img title="Run code" src="play.png" class="run" /></a>
+          <a href="http://play.golang.org/p/OdDXjyHCVB"><img title="Run code" src="play.png" class="run" /></a>
             <div class="highlight"><pre><span class="kn">package</span> <span class="nx">main</span>
 </pre></div>
 

--- a/public/line-filters
+++ b/public/line-filters
@@ -37,7 +37,7 @@ line filters.</p>
         
         <tr>
           <td class="docs">
-            <p>Here’s an example line filter in Go that writes a
+            <p>Here&rsquo;s an example line filter in Go that writes a
 capitalized version of all input text. You can use this
 pattern to write your own Go line filters.</p>
 

--- a/public/mapas
+++ b/public/mapas
@@ -160,7 +160,7 @@ se utiliza con un mapa.</p>
 value from a map indicates if the key was present
 in the map. This can be used to disambiguate
 between missing keys and keys with zero values
-like <code>0</code> or <code>&#34;&#34;</code>.</p>
+like <code>0</code> or <code>&quot;&quot;</code>.</p>
 
           </td>
           <td class="code empty leading">
@@ -174,7 +174,7 @@ like <code>0</code> or <code>&#34;&#34;</code>.</p>
             <p>El segundo valor de regreso (opcional) cuando obtienes un valor de
 el mapa indica si la llave etaba presente. Este valor puede
 ser usado para separar valores de llaves que no existen y
-valores de llaves con valor cero, como <code>0</code> o <code>&#34;&#34;</code>.</p>
+valores de llaves con valor cero, como <code>0</code> o <code>&quot;&quot;</code>.</p>
 
           </td>
           <td class="code leading">

--- a/public/mutexes
+++ b/public/mutexes
@@ -107,7 +107,7 @@ to safely access data across multiple goroutines.</p>
         <tr>
           <td class="docs">
             <p>To compare the mutex-based approach with another
-we’ll see later, <code>ops</code> will count how many
+we&rsquo;ll see later, <code>ops</code> will count how many
 operations we perform against the state.</p>
 
           </td>
@@ -161,7 +161,7 @@ the <code>ops</code> count.</p>
         <tr>
           <td class="docs">
             <p>In order to ensure that this goroutine
-doesn’t starve the scheduler, we explicitly
+doesn&rsquo;t starve the scheduler, we explicitly
 yield after each operation with
 <code>runtime.Gosched()</code>. This yielding is
 handled automatically with e.g. every
@@ -183,7 +183,7 @@ case we need to do it manually.</p>
         
         <tr>
           <td class="docs">
-            <p>We’ll also start 10 goroutines to simulate writes,
+            <p>We&rsquo;ll also start 10 goroutines to simulate writes,
 using the same pattern we did for reads.</p>
 
           </td>
@@ -274,7 +274,7 @@ using the same pattern we did for reads.</p>
         
         <tr>
           <td class="docs">
-            <p>Next we’ll look at implementing this same state
+            <p>Next we&rsquo;ll look at implementing this same state
 management task using only goroutines and channels.</p>
 
           </td>

--- a/public/random-numbers
+++ b/public/random-numbers
@@ -23,7 +23,7 @@
         
         <tr>
           <td class="docs">
-            <p>Go’s <code>math/rand</code> package provides
+            <p>Go&rsquo;s <code>math/rand</code> package provides
 <a href="http://en.wikipedia.org/wiki/Pseudorandom_number_generator">pseudorandom number</a>
 generation.</p>
 
@@ -104,7 +104,7 @@ generation.</p>
         <tr>
           <td class="docs">
             <p>This can be used to generate random floats in
-other ranges, for example <code>5.0 &lt;= f&#39; &lt; 10.0</code>.</p>
+other ranges, for example <code>5.0 &lt;= f' &lt; 10.0</code>.</p>
 
           </td>
           <td class="code leading">

--- a/public/reading-files
+++ b/public/reading-files
@@ -24,7 +24,7 @@
         <tr>
           <td class="docs">
             <p>Reading and writing files are basic tasks needed for
-many Go programs. First we’ll look at some examples of
+many Go programs. First we&rsquo;ll look at some examples of
 reading files.</p>
 
           </td>
@@ -97,7 +97,7 @@ This helper will streamline our error checks below.</p>
         <tr>
           <td class="docs">
             <p>Perhaps the most basic file reading task is
-slurping a file’s entire contents into memory.</p>
+slurping a file&rsquo;s entire contents into memory.</p>
 
           </td>
           <td class="code leading">
@@ -112,7 +112,7 @@ slurping a file’s entire contents into memory.</p>
         
         <tr>
           <td class="docs">
-            <p>You’ll often want more control over how and what
+            <p>You&rsquo;ll often want more control over how and what
 parts of a file are read. For these tasks, start
 by <code>Open</code>ing a file to obtain an <code>os.File</code> value.</p>
 
@@ -220,7 +220,7 @@ reading methods it provides.</p>
         
         <tr>
           <td class="docs">
-            <p>Close the file when you’re done (usually this would
+            <p>Close the file when you&rsquo;re done (usually this would
 be scheduled immediately after <code>Open</code>ing with
 <code>defer</code>).</p>
 
@@ -271,7 +271,7 @@ be scheduled immediately after <code>Open</code>ing with
         
         <tr>
           <td class="docs">
-            <p>Next we’ll look at writing files.</p>
+            <p>Next we&rsquo;ll look at writing files.</p>
 
           </td>
           <td class="code empty">

--- a/public/select
+++ b/public/select
@@ -136,7 +136,7 @@ simultaneamente, y mostraremos cada uno conforme llegue.</p>
         
         <tr>
           <td class="docs">
-            <p>Recibimos los valores <code>&#34;uno&#34;</code> y luego <code>&#34;dos&#34;</code>
+            <p>Recibimos los valores <code>&quot;uno&quot;</code> y luego <code>&quot;dos&quot;</code>
 tal y como lo esperamos.</p>
 
           </td>

--- a/public/sha1-hashes
+++ b/public/sha1-hashes
@@ -27,7 +27,7 @@
 frequently used to compute short identities for binary
 or text blobs. For example, the <a href="http://git-scm.com/">git revision control
 system</a> uses SHA1s extensively to
-identify versioned files and directories. Here’s how to
+identify versioned files and directories. Here&rsquo;s how to
 compute SHA1 hashes in Go.</p>
 
           </td>
@@ -110,7 +110,7 @@ use <code>[]byte(s)</code> to coerce it to bytes.</p>
           <td class="docs">
             <p>This gets the finalized hash result as a byte
 slice. The argument to <code>Sum</code> can be used to append
-to an existing byte slice: it usually isn’t needed.</p>
+to an existing byte slice: it usually isn&rsquo;t needed.</p>
 
           </td>
           <td class="code leading">

--- a/public/signals
+++ b/public/signals
@@ -23,12 +23,12 @@
         
         <tr>
           <td class="docs">
-            <p>Sometimes we’d like our Go programs to intelligently
+            <p>Sometimes we&rsquo;d like our Go programs to intelligently
 handle <a href="http://en.wikipedia.org/wiki/Unix_signal">Unix signals</a>.
 For example, we might want a server to gracefully
 shutdown when it receives a <code>SIGTERM</code>, or a command-line
 tool to stop processing input if it receives a <code>SIGINT</code>.
-Here’s how to handle signals in Go with channels.</p>
+Here&rsquo;s how to handle signals in Go with channels.</p>
 
           </td>
           <td class="code empty leading">
@@ -79,8 +79,8 @@ Here’s how to handle signals in Go with channels.</p>
         <tr>
           <td class="docs">
             <p>Go signal notification works by sending <code>os.Signal</code>
-values on a channel. We’ll create a channel to
-receive these notifications (we’ll also make one to
+values on a channel. We&rsquo;ll create a channel to
+receive these notifications (we&rsquo;ll also make one to
 notify us when the program can exit).</p>
 
           </td>
@@ -110,7 +110,7 @@ receive notifications of the specified signals.</p>
         <tr>
           <td class="docs">
             <p>This goroutine executes a blocking receive for
-signals. When it gets one it’ll print it out
+signals. When it gets one it&rsquo;ll print it out
 and then notify the program that it can finish.</p>
 
           </td>

--- a/public/spawning-processes
+++ b/public/spawning-processes
@@ -27,7 +27,7 @@
 processes. For example, the syntax highlighting on this
 site is <a href="https://github.com/mmcgrana/gobyexample/blob/master/tools/generate.go">implemented</a>
 by spawning a <a href="http://pygments.org/"><code>pygmentize</code></a>
-process from a Go program. Let’s look at a few examples
+process from a Go program. Let&rsquo;s look at a few examples
 of spawning processes from Go.</p>
 
           </td>
@@ -77,7 +77,7 @@ of spawning processes from Go.</p>
         
         <tr>
           <td class="docs">
-            <p>We’ll start with a simple command that takes no
+            <p>We&rsquo;ll start with a simple command that takes no
 arguments or input and just prints something to
 stdout. The <code>exec.Command</code> helper creates an object
 to represent this external process.</p>
@@ -114,7 +114,7 @@ and collecting its output. If there were no errors,
         
         <tr>
           <td class="docs">
-            <p>Next we’ll look at a slightly more involved case
+            <p>Next we&rsquo;ll look at a slightly more involved case
 where we pipe data to the external process on its
 <code>stdin</code> and collect the results from its <code>stdout</code>.</p>
 
@@ -173,7 +173,7 @@ exactly the same way.</p>
 provide an explicitly delineated command and
 argument array, vs. being able to just pass in one
 command-line string. If you want to spawn a full
-command with a string, you can use <code>bash</code>’s <code>-c</code>
+command with a string, you can use <code>bash</code>&rsquo;s <code>-c</code>
 option:</p>
 
           </td>

--- a/public/stateful-goroutines
+++ b/public/stateful-goroutines
@@ -28,7 +28,7 @@ mutexes to synchronize access to shared state across
 multiple goroutines. Another option is to use the
 built-in synchronization features of  goroutines and
 channels to achieve the same result. This channel-based
-approach aligns with Go’s ideas of sharing memory by
+approach aligns with Go&rsquo;s ideas of sharing memory by
 communicating and having each piece of data owned
 by exactly 1 goroutine.</p>
 
@@ -110,7 +110,7 @@ goroutine to respond.</p>
         
         <tr>
           <td class="docs">
-            <p>As before we’ll count how many operations we perform.</p>
+            <p>As before we&rsquo;ll count how many operations we perform.</p>
 
           </td>
           <td class="code leading">

--- a/public/tickers
+++ b/public/tickers
@@ -23,7 +23,7 @@
         
         <tr>
           <td class="docs">
-            <p>Los <a>temporizadores</a> se usan cuando
+            <p>Los <a href="temporizadores">temporizadores</a> se usan cuando
 quieres hacer una cosa en el futuro - los <em>tickers</em>
 ( por aquello de tic tac ) - se usan cuando se quiere
 hacer algo repetidamente en intervalos regulares.

--- a/public/variables
+++ b/public/variables
@@ -131,7 +131,7 @@ varibale de tipo <code>int</code> es <code>0</code>.</p>
         <tr>
           <td class="docs">
             <p>La syntaxis <code>:=</code> es la abreviación para declarar e inicializar
-una variable, e.g. de <code>var f string = &#34;short&#34;</code> en este caso.</p>
+una variable, e.g. de <code>var f string = &quot;short&quot;</code> en este caso.</p>
 
           </td>
           <td class="code">

--- a/tools/build
+++ b/tools/build
@@ -2,6 +2,6 @@
 
 set -e
 
-tools/gofmt
+tools/format
 tools/measure
 tools/generate

--- a/tools/format
+++ b/tools/format
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eo pipefail
+
+paths=$(ls tools/*.go examples/*/*.go)
+
+gbe_to_4spaces() {
+  local os=$(tr [A-Z] [a-z] <<< "`uname`")
+  case $os in
+    darwin*)
+      sed -i '' -e 's/	/    /g' $1
+      ;;
+    linux*)
+      sed -i -e 's/	/    /g' $1
+      ;;
+    *)
+      echo "$os is not supported."
+      echo "Add a proper 'sed' command for your platform to ./tools/format"
+      return 1
+      ;;
+  esac
+}
+
+for path in $paths; do
+  gofmt -w=true $path
+  gbe_to_4spaces $path
+done

--- a/tools/gofmt
+++ b/tools/gofmt
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-set -e
-set -o pipefail
-
-ls tools/*.go examples/*/*.go | xargs gofmt -tabs=false -tabwidth=4 -w=true

--- a/tools/server.go
+++ b/tools/server.go
@@ -1,58 +1,58 @@
 package main
 
 import (
-	"flag"
-	"log"
-	"net/http"
-	"os"
+    "flag"
+    "log"
+    "net/http"
+    "os"
 )
 
 const (
-	root   = `/`
-	source = `public`
+    root   = `/`
+    source = `public`
 )
 
 var listen = flag.String("listen", ":8000", "Listen address.")
 
 func init() {
-	flag.Parse()
+    flag.Parse()
 }
 
 type rootHandler struct {
 }
 
 func fileExists(name string) bool {
-	if _, err := os.Stat(name); err != nil {
-		return false
-	}
-	return true
+    if _, err := os.Stat(name); err != nil {
+        return false
+    }
+    return true
 }
 
 func (self *rootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	switch r.URL.Path {
-	case `/`:
-		http.ServeFile(w, r, source+`/index.html`)
-	case `/index.html`, `/site.css`, `/favicon.ico`, `play.png`:
-		http.ServeFile(w, r, source+r.URL.Path)
-	default:
-		rsc := r.URL.Path
-		if fileExists(source + `/` + rsc) {
-			w.Header().Add(`Content-Type`, `text/html; charset=utf-8`)
-			http.ServeFile(w, r, source+rsc)
-		} else {
-			http.ServeFile(w, r, source+`/404.html`)
-		}
-	}
+    switch r.URL.Path {
+    case `/`:
+        http.ServeFile(w, r, source+`/index.html`)
+    case `/index.html`, `/site.css`, `/favicon.ico`, `play.png`:
+        http.ServeFile(w, r, source+r.URL.Path)
+    default:
+        rsc := r.URL.Path
+        if fileExists(source + `/` + rsc) {
+            w.Header().Add(`Content-Type`, `text/html; charset=utf-8`)
+            http.ServeFile(w, r, source+rsc)
+        } else {
+            http.ServeFile(w, r, source+`/404.html`)
+        }
+    }
 }
 
 func main() {
-	var err error
-	http.Handle(root, &rootHandler{})
+    var err error
+    http.Handle(root, &rootHandler{})
 
-	log.Printf("Serving HTTP at: %s", *listen)
+    log.Printf("Serving HTTP at: %s", *listen)
 
-	if err = http.ListenAndServe(*listen, nil); err != nil {
-		log.Fatalf("ListenAndServe: %q", err)
-	}
+    if err = http.ListenAndServe(*listen, nil); err != nil {
+        log.Fatalf("ListenAndServe: %q", err)
+    }
 
 }


### PR DESCRIPTION
Me traje este commit del repo original: [Update format script for new gofmt](https://github.com/mmcgrana/gobyexample/commit/8e7a6bb08685033cddff20f626896fd269b403b7), pero el comando `sed` (con el que se sustituyen los tabs por 4 espacios) no funcionaba en Linux, sólo en OS X (Mac), agregué código para detectar el OS y ejecutar el comando adecuado, aunque sólo para Darwin y Linux, pero supongo que con eso bastaría para cubrir buena parte de las plataformas que se usan.

A diferencia de lo que dice el nombre de la rama, ahora se pueden usar 1.2, 1.3 y 1.4.

Comentario del commit original:

gofmt no longer supports `tabs` and `tabwidth`, but we still require
exactly-4-space tabs to preserve the narrow layout on gobyexample.com,
so re-implement this functionality with sed.